### PR TITLE
Add shared UART with analog commutator and ChipSelect pin

### DIFF
--- a/examples/TMC2208_SharedUART/TMC2208_SharedUART.ino
+++ b/examples/TMC2208_SharedUART/TMC2208_SharedUART.ino
@@ -1,0 +1,58 @@
+// Author Teemu Mantykallio, 2017-04-07
+
+// Define pins
+// 1st motor
+#define EN_PIN_1    13												// LOW: Driver enabled. HIGH: Driver disabled
+#define STEP_PIN_1  54												// Step on rising edge
+#define CS_PIN_1    14												// driver UART select pin
+
+// 2nd motor
+#define EN_PIN_2    15												// LOW: Driver enabled. HIGH: Driver disabled
+#define STEP_PIN_2  55												// Step on rising edge
+#define CS_PIN_2    16												// driver UART select pin
+
+#include <TMC2208Stepper.h>											// Include library
+
+#define SHARED_UART	Serial1
+
+TMC2208Stepper driver1 = TMC2208Stepper(&SHARED_UART, true, CS_PIN_1);	// Create drivers and use SHARED_UART for bi-directional communication
+TMC2208Stepper driver2 = TMC2208Stepper(&SHARED_UART, true, CS_PIN_2);	// Create drivers and use SHARED_UART for bi-directional communication
+
+void setup() {
+	SHARED_UART.begin(115200);			// Init used serial port
+	while(!SHARED_UART);				// Wait for port to be ready
+
+    // Prepare pins
+	pinMode(EN_PIN_1, OUTPUT);
+	pinMode(STEP_PIN_1, OUTPUT);
+
+	pinMode(EN_PIN_2, OUTPUT);
+	pinMode(STEP_PIN_2, OUTPUT);
+
+	// prepare drivers
+	driver1.pdn_disable(1);				// Use PDN/UART pin for communication
+	driver1.replyDelay = 2;				// Delay in ms to wait for driver to reply (on Due 1ms is enough)
+	driver1.I_scale_analog(0);			// Adjust current from the registers
+	driver1.rms_current(500);			// Set driver current 500mA
+	driver1.toff(0x2);					// Enable driver
+	driver1.microsteps(32);				// Set microsteps
+
+	digitalWrite(EN_PIN_1, LOW);		// Enable driver
+
+
+	driver2.pdn_disable(1);				// Use PDN/UART pin for communication
+	driver2.replyDelay = 2;				// Delay in ms to wait for driver to reply (on Due 1ms is enough)
+	driver2.I_scale_analog(0);			// Adjust current from the registers
+	driver2.rms_current(500);			// Set driver current 500mA
+	driver2.toff(0x2);					// Enable driver
+	driver1.microsteps(16);				// Set microsteps
+
+	digitalWrite(EN_PIN_2, LOW);		// Enable driver
+}
+
+void loop() {
+	digitalWrite(STEP_PIN_1, !digitalRead(STEP_PIN_1));	// Step
+	delay(2);
+	digitalWrite(STEP_PIN_2, !digitalRead(STEP_PIN_2));	// Step
+	delay(2);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -80,9 +80,9 @@ cur_b										KEYWORD2
 CHOPCONF								KEYWORD2
 toff										KEYWORD2
 hstrt										KEYWORD2
-hysterisis_start				KEYWORD2
+hysteresis_start				KEYWORD2
 hend										KEYWORD2
-hysterisis_end  				KEYWORD2
+hysteresis_end  				KEYWORD2
 tbl											KEYWORD2
 vsense									KEYWORD2
 mres										KEYWORD2

--- a/src/TMC2208Stepper.h
+++ b/src/TMC2208Stepper.h
@@ -114,9 +114,9 @@ class TMC2208Stepper {
 		void CHOPCONF(uint32_t input);
 		void toff(uint8_t B);
 		void hstrt(uint8_t B);
-		void hysterisis_start(uint8_t value);
+		void hysteresis_start(uint8_t value);
 		void hend(uint8_t B);
-		void hysterisis_end(int8_t value);
+		void hysteresis_end(int8_t value);
 		void tbl(uint8_t B);
 		void blank_time(uint8_t B);
 		void vsense(bool B);
@@ -128,9 +128,9 @@ class TMC2208Stepper {
 		bool CHOPCONF(uint32_t *data);
 		uint8_t toff();
 		uint8_t hstrt();
-		uint8_t hysterisis_start();
+		uint8_t hysteresis_start();
 		uint8_t hend();
-		int8_t hysterisis_end();
+		int8_t hysteresis_end();
 		uint8_t tbl();
 		uint8_t blank_time();
 		bool vsense();

--- a/src/TMC2208Stepper.h
+++ b/src/TMC2208Stepper.h
@@ -12,7 +12,8 @@
 class TMC2208Stepper {
 	public:
 		//TMC2208Stepper(HardwareSerial& serial);
-		TMC2208Stepper(Stream * serial, bool has_rx=true);
+		//TMC2208Stepper(Stream * serial, bool has_rx=true);
+		TMC2208Stepper(Stream * serial, bool has_rx=true, uint8_t cs_pin=0);
 		void rms_current(uint16_t mA, float multiplier=0.5, float RS=0.11);
 		uint16_t rms_current();
 		void microsteps(uint16_t ms);
@@ -182,6 +183,7 @@ class TMC2208Stepper {
 
 		bool isWriteOnly() {return write_only;}
 
+		uint8_t cs_pin() {return cs_pin_val;}
 		uint16_t bytesWritten = 0;
 		float Rsense = 0.11;
 		uint16_t replyDelay = 10;
@@ -207,6 +209,7 @@ class TMC2208Stepper {
 
 		bool write_only;
 		uint16_t mA_val = 0;
+		uint8_t cs_pin_val = 0;
 };
 
 #endif

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -3,9 +3,14 @@
 #include "TMC2208Stepper_MACROS.h"
 
 //TMC2208Stepper::TMC2208Stepper(HardwareSerial& SR) : TMC_SERIAL(SR) {}
-TMC2208Stepper::TMC2208Stepper(Stream * SR, bool has_rx) {
+TMC2208Stepper::TMC2208Stepper(Stream * SR, bool has_rx, uint8_t cs_pin) {
 	TMC_SERIAL = SR;
 	write_only = !has_rx;
+	cs_pin_val = cs_pin;
+	if (cs_pin_val > 0) {
+		pinMode(cs_pin_val, OUTPUT);
+		digitalWrite(cs_pin_val, LOW);
+	}
 }
 
 /*	
@@ -128,6 +133,10 @@ uint8_t TMC2208Stepper::calcCRC(uint8_t datagram[], uint8_t len) {
 }
 
 void TMC2208Stepper::sendDatagram(uint8_t addr, uint32_t regVal, uint8_t len) {
+	if (cs_pin_val > 0) {
+		digitalWrite ( cs_pin_val, HIGH );
+	}
+
 	uint8_t datagram[] = {TMC2208_SYNC, TMC2208_SLAVE_ADDR, addr, (uint8_t)(regVal>>24), (uint8_t)(regVal>>16), (uint8_t)(regVal>>8), (uint8_t)(regVal>>0), 0x00};
 
 	datagram[len] = calcCRC(datagram, len);
@@ -135,9 +144,16 @@ void TMC2208Stepper::sendDatagram(uint8_t addr, uint32_t regVal, uint8_t len) {
 	for(int i=0; i<=len; i++){
 		bytesWritten += TMC_SERIAL->write(datagram[i]);
 	}
+	if (cs_pin_val > 0) {
+		digitalWrite ( cs_pin_val, LOW );
+	}
 }
 
 bool TMC2208Stepper::sendDatagram(uint8_t addr, uint32_t *data, uint8_t len) {
+	if (cs_pin_val > 0) {
+		digitalWrite ( cs_pin_val, HIGH );
+	}
+
 	uint8_t datagram[] = {TMC2208_SYNC, TMC2208_SLAVE_ADDR, addr, 0x00};
 	datagram[len] = calcCRC(datagram, len);
 
@@ -154,6 +170,10 @@ bool TMC2208Stepper::sendDatagram(uint8_t addr, uint32_t *data, uint8_t len) {
 		uint8_t res = TMC_SERIAL->read();
 		out <<= 8;
 		out |= res&0xFF;
+	}
+
+	if (cs_pin_val > 0) {
+		digitalWrite ( cs_pin_val, LOW );
 	}
 
 	uint8_t out_datagram[] = {(uint8_t)(out>>56), (uint8_t)(out>>48), (uint8_t)(out>>40), (uint8_t)(out>>32), (uint8_t)(out>>24), (uint8_t)(out>>16), (uint8_t)(out>>8), (uint8_t)(out>>0)};

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -144,6 +144,9 @@ void TMC2208Stepper::sendDatagram(uint8_t addr, uint32_t regVal, uint8_t len) {
 	for(int i=0; i<=len; i++){
 		bytesWritten += TMC_SERIAL->write(datagram[i]);
 	}
+
+	TMC_SERIAL->flush(); // Wait for TX to finish
+
 	if (cs_pin_val > 0) {
 		digitalWrite ( cs_pin_val, LOW );
 	}

--- a/src/source/TMC2208Stepper_CHOPCONF.cpp
+++ b/src/source/TMC2208Stepper_CHOPCONF.cpp
@@ -35,8 +35,8 @@ bool 	TMC2208Stepper::dedge()		{ GET_BYTE(CHOPCONF, DEDGE);  	}
 bool 	TMC2208Stepper::diss2g()	{ GET_BYTE(CHOPCONF, DISS2G); 	}
 bool 	TMC2208Stepper::diss2vs()	{ GET_BYTE(CHOPCONF, DISS2VS);	}
 
-void TMC2208Stepper::hysterisis_end(int8_t value) { hend(value+3); }
-int8_t TMC2208Stepper::hysterisis_end() { return hend()-3; };
+void TMC2208Stepper::hysteresis_end(int8_t value) { hend(value+3); }
+int8_t TMC2208Stepper::hysteresis_end() { return hend()-3; };
 
-void TMC2208Stepper::hysterisis_start(uint8_t value) { hstrt(value-1); }
-uint8_t TMC2208Stepper::hysterisis_start() { return hstrt()+1; }
+void TMC2208Stepper::hysteresis_start(uint8_t value) { hstrt(value-1); }
+uint8_t TMC2208Stepper::hysteresis_start() { return hstrt()+1; }


### PR DESCRIPTION
Small patch to enable use of shared UART with analog commutator like 77HC4066 for multiple TMC2208 drivers. This might be suitable for platforms like Arduino Due which don't have software UART library implementations.
In this scenario drivers should be connected as shown on TMC2208 datasheet (https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC220x_TMC222x_Datasheet.pdf), page 22, figure 4.2. And ChipSelect pins (port pins in the datasheet) should be defined and used in TMC2208Stepper class constructors.
Examples compile for both avr and due architectures, so I guess, that "avr-only" limitation can be shifted.