### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes KEYWORD1
 #######################################
 
-Stepper	TMC2208Stepper	KEYWORD1
+TMC2208Stepper	KEYWORD1
 
 #######################################
 # Methods and Functions KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,116 +12,116 @@ TMC2208Stepper	KEYWORD1
 # Methods and Functions KEYWORD2
 #######################################
 
-rms_current							KEYWORD2
-microsteps							KEYWORD2
-setCurrent							KEYWORD2
-getCurrent							KEYWORD2
-checkOT									KEYWORD2
-getOTPW									KEYWORD2
-clear_otpw							KEYWORD2
+rms_current	KEYWORD2
+microsteps	KEYWORD2
+setCurrent	KEYWORD2
+getCurrent	KEYWORD2
+checkOT	KEYWORD2
+getOTPW	KEYWORD2
+clear_otpw	KEYWORD2
 
-GCONF										KEYWORD2
-I_scale_analog					KEYWORD2
-internal_Rsense					KEYWORD2
-en_spreadCycle					KEYWORD2
-shaft										KEYWORD2
-index_otpw							KEYWORD2
-index_step							KEYWORD2
-pdn_disable							KEYWORD2
-mstep_reg_select				KEYWORD2
-multistep_filt					KEYWORD2
+GCONF	KEYWORD2
+I_scale_analog	KEYWORD2
+internal_Rsense	KEYWORD2
+en_spreadCycle	KEYWORD2
+shaft	KEYWORD2
+index_otpw	KEYWORD2
+index_step	KEYWORD2
+pdn_disable	KEYWORD2
+mstep_reg_select	KEYWORD2
+multistep_filt	KEYWORD2
 
-GSTAT										KEYWORD2
-reset										KEYWORD2
-drv_err									KEYWORD2
-uv_cp										KEYWORD2
+GSTAT	KEYWORD2
+reset	KEYWORD2
+drv_err	KEYWORD2
+uv_cp	KEYWORD2
 
-IFCNT										KEYWORD2
+IFCNT	KEYWORD2
 
-SLAVECONF								KEYWORD2
-senddelay								KEYWORD2
+SLAVECONF	KEYWORD2
+senddelay	KEYWORD2
 
-OTP_PROG								KEYWORD2
+OTP_PROG	KEYWORD2
 
-IOIN										KEYWORD2
-enn											KEYWORD2
-ms1											KEYWORD2
-ms2											KEYWORD2
-diag										KEYWORD2
-pdn_uart								KEYWORD2
-step										KEYWORD2
-sel_a										KEYWORD2
-dir											KEYWORD2
-version									KEYWORD2
+IOIN	KEYWORD2
+enn	KEYWORD2
+ms1	KEYWORD2
+ms2	KEYWORD2
+diag	KEYWORD2
+pdn_uart	KEYWORD2
+step	KEYWORD2
+sel_a	KEYWORD2
+dir	KEYWORD2
+version	KEYWORD2
 
-FACTORY_CONF						KEYWORD2
-fclktrim								KEYWORD2
-ottrim									KEYWORD2
+FACTORY_CONF	KEYWORD2
+fclktrim	KEYWORD2
+ottrim	KEYWORD2
 
-IHOLD_IRUN							KEYWORD2
-ihold										KEYWORD2
-irun										KEYWORD2
-iholddelay							KEYWORD2
+IHOLD_IRUN	KEYWORD2
+ihold	KEYWORD2
+irun	KEYWORD2
+iholddelay	KEYWORD2
 
-TPOWERDOWN							KEYWORD2
+TPOWERDOWN	KEYWORD2
 
-TSTEP										KEYWORD2
+TSTEP	KEYWORD2
 
-TPWMTHRS								KEYWORD2
+TPWMTHRS	KEYWORD2
 
-VACTUAL									KEYWORD2
+VACTUAL	KEYWORD2
 
-MSCNT										KEYWORD2
+MSCNT	KEYWORD2
 
-MSCURACT								KEYWORD2
-cur_a										KEYWORD2
-cur_b										KEYWORD2
+MSCURACT	KEYWORD2
+cur_a	KEYWORD2
+cur_b	KEYWORD2
 
-CHOPCONF								KEYWORD2
-toff										KEYWORD2
-hstrt										KEYWORD2
-hysteresis_start				KEYWORD2
-hend										KEYWORD2
-hysteresis_end  				KEYWORD2
-tbl											KEYWORD2
-vsense									KEYWORD2
-mres										KEYWORD2
-intpol									KEYWORD2
-dedge										KEYWORD2
-diss2g									KEYWORD2
-diss2vs									KEYWORD2
+CHOPCONF	KEYWORD2
+toff	KEYWORD2
+hstrt	KEYWORD2
+hysteresis_start	KEYWORD2
+hend	KEYWORD2
+hysteresis_end	KEYWORD2
+tbl	KEYWORD2
+vsense	KEYWORD2
+mres	KEYWORD2
+intpol	KEYWORD2
+dedge	KEYWORD2
+diss2g	KEYWORD2
+diss2vs	KEYWORD2
 
-DRV_STATUS							KEYWORD2
-otpw										KEYWORD2
-ot											KEYWORD2
-s2ga										KEYWORD2
-s2gb										KEYWORD2
-s2vsa										KEYWORD2
-s2vsb										KEYWORD2
-ola											KEYWORD2
-olb											KEYWORD2
-t120										KEYWORD2
-t143										KEYWORD2
-t150										KEYWORD2
-t157										KEYWORD2
-cs_actual								KEYWORD2
-stealth									KEYWORD2
-stst										KEYWORD2
+DRV_STATUS	KEYWORD2
+otpw	KEYWORD2
+ot	KEYWORD2
+s2ga	KEYWORD2
+s2gb	KEYWORD2
+s2vsa	KEYWORD2
+s2vsb	KEYWORD2
+ola	KEYWORD2
+olb	KEYWORD2
+t120	KEYWORD2
+t143	KEYWORD2
+t150	KEYWORD2
+t157	KEYWORD2
+cs_actual	KEYWORD2
+stealth	KEYWORD2
+stst	KEYWORD2
 
-PWMCONF									KEYWORD2
-pwm_ofs									KEYWORD2
-pwm_grad								KEYWORD2
-pwm_freq								KEYWORD2
-pwm_autoscale						KEYWORD2
-pwm_autograd						KEYWORD2
-freewheel								KEYWORD2
-pwm_reg									KEYWORD2
-pwm_lim									KEYWORD2
+PWMCONF	KEYWORD2
+pwm_ofs	KEYWORD2
+pwm_grad	KEYWORD2
+pwm_freq	KEYWORD2
+pwm_autoscale	KEYWORD2
+pwm_autograd	KEYWORD2
+freewheel	KEYWORD2
+pwm_reg	KEYWORD2
+pwm_lim	KEYWORD2
 
-PWM_SCALE								KEYWORD2
-pwm_scale_sum						KEYWORD2
-pwm_scale_auto					KEYWORD2
+PWM_SCALE	KEYWORD2
+pwm_scale_sum	KEYWORD2
+pwm_scale_auto	KEYWORD2
 
-bytesWritten						KEYWORD2
-Rsense									KEYWORD2
-replyDelay							KEYWORD2
+bytesWritten	KEYWORD2
+Rsense	KEYWORD2
+replyDelay	KEYWORD2


### PR DESCRIPTION
- Fix formatting error.
- Use a single tab field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords