### PR TITLE
Fix typo in SW_CAPABLE_PLATFORM block

### DIFF
--- a/src/TMC2208Stepper.h
+++ b/src/TMC2208Stepper.h
@@ -218,6 +218,9 @@ class TMC2208Stepper {
 		Stream * HWSerial = NULL;
 		#if SW_CAPABLE_PLATFORM
 			SoftwareSerial * SWSerial = NULL;
+			bool uses_sw_serial;
+		#else
+			constexpr static bool uses_sw_serial = false;
 		#endif
 		void sendDatagram(uint8_t addr, uint32_t regVal, uint8_t len=7);
 		bool sendDatagram(uint8_t addr, uint32_t *data, uint8_t len=3);
@@ -239,7 +242,6 @@ class TMC2208Stepper {
 					tmp_sr = 			0x00000000UL;
 
 		bool write_only;
-		bool uses_sw_serial;
 		uint16_t mA_val = 0;
 };
 

--- a/src/source/TMC2208Stepper_PWMCONF.cpp
+++ b/src/source/TMC2208Stepper_PWMCONF.cpp
@@ -31,4 +31,3 @@ bool 	TMC2208Stepper::pwm_autograd()	{ GET_BYTE(PWMCONF, PWM_AUTOGRAD);	}
 uint8_t TMC2208Stepper::freewheel()		{ GET_BYTE(PWMCONF, FREEWHEEL);		}
 uint8_t TMC2208Stepper::pwm_reg()		{ GET_BYTE(PWMCONF, PWM_REG);		}
 uint8_t TMC2208Stepper::pwm_lim()		{ GET_BYTE(PWMCONF, PWM_LIM);		}
-


### PR DESCRIPTION
- The constructor for SW serial was being included accidentally.
- The `uses_sw_serial` variable can be `static constexpr` without `SW_CAPABLE_PLATFORM`.